### PR TITLE
Replace global region with reference

### DIFF
--- a/src/cpu.effekt
+++ b/src/cpu.effekt
@@ -54,23 +54,23 @@ def convertKey(key: String): Int = key match {
 
 def makeCPU() {r: Renderer} = {
   // Initialize the RAM
-  var ram in global = makeRam()
+  val ram = makeRam()
   
   // Initialize the CPU registers
-  var v: ByteArray in global = allocate(16) // 16 8-bit registers
-  var i: Int in global = 0 // 16-bit register treat as 12-bit !!!
+  val v: Ref[ByteArray] = ref(allocate(16)) // 16 8-bit registers
+  val i = ref(0) // 16-bit register treat as 12-bit !!!
 
-  var delay: Byte in global = 0.toByte() // Delay timer
-  var sound: Byte in global = 0.toByte() // Sound timer
-  var pc: Int in global = 512 // Program counter
-  var sp: Byte in global = 0.toByte() // Stack pointer
+  val delay = ref(0.toByte()) // Delay timer
+  val sound = ref(0.toByte()) // Sound timer
+  val pc = ref(512) // Program counter
+  val sp = ref(0.toByte()) // Stack pointer
   // After checking the implementation of queue in Effekt, I realized that it also works as a stack, so I will use it as a stack
-  var stack in global = emptyQueue[Int](32) // Stack with 16 levels. Each level is 16-bit that is 2 bytes, so 32 bytes
+  val stack = ref(emptyQueue[Int](32)) // Stack with 16 levels. Each level is 16-bit that is 2 bytes, so 32 bytes
 
-  var last_key_update_time in global = getNow()
-  var last_instruction_run_time in global = getNow()
-  var last_display_update_time in global = getNow()
-  var last_timer_update in global = getNow()
+  val last_key_update_time = ref(getNow())
+  val last_instruction_run_time = ref(getNow())
+  val last_display_update_time = ref(getNow())
+  val last_timer_update = ref(getNow())
 
   new CPU {
     def initCPU(rom: ByteArray) = {
@@ -80,17 +80,17 @@ def makeCPU() {r: Renderer} = {
     def cycleCPU() = {
       val currentTime = getNow()
       var key: Int = -1 // Key pressed
-      if (currentTime - last_key_update_time >= 1) { 
+      if (currentTime - last_key_update_time.get >= 1) { 
         val key_ = r.getKeyPressed().getOrElse { "P" }
         if (key_ != "P") {
           key = convertKey(key_)
         }
-        last_key_update_time = currentTime
+        last_key_update_time.set(currentTime)
       }
 
-      if (currentTime - last_instruction_run_time >= 2) { // ~500Hz
-        val h = ram.getAddr(pc)
-        val l = ram.getAddr(pc + 1)
+      if (currentTime - last_instruction_run_time.get >= 2) { // ~500Hz
+        val h = ram.getAddr(pc.get)
+        val l = ram.getAddr(pc.get + 1)
         val inst = bitwiseOr(bitwiseShl(h.toInt(), 8), l.toInt())
 
         // Decode
@@ -108,155 +108,155 @@ def makeCPU() {r: Renderer} = {
               // Clear the screen
               case 224 => {
                 r.clear()
-                pc = pc + 2
+                pc.set(pc.get + 2)
               }
               // Return from a subroutine
               case 238 => {
-                // pc = stack[Int].popFront[Int]().value[Int]()
-                pc = stack.popFront().getOrElse { 0 }
+                // pc.set(stack[Int].popFront[Int]().value[Int]())
+                pc.set(stack.get.popFront().getOrElse { 0 })
               }
             } else {
               // 0nnn - SYS addr - Jump to a machine code routine at nnn
-              pc = nnn
+              pc.set(nnn)
             }
           }
           // Jump to address NNN
           case 1 => {
-            pc = nnn
+            pc.set(nnn)
           }
           // Call subroutine at NNN
           case 2 => {
-            stack.pushFront(pc + 2)
-            pc = nnn
+            stack.get.pushFront(pc.get + 2)
+            pc.set(nnn)
           }
           // Skip next instruction if VX == NN
           case 3 => {
-            if (v.unsafeGet(x).toInt() == nn) {
-              pc = pc + 2
+            if (v.get.unsafeGet(x).toInt() == nn) {
+              pc.set(pc.get + 2)
             }
-            pc = pc + 2
+            pc.set(pc.get + 2)
           }
           // Skip next instruction if VX != NN
           case 4 => {
-            if (v.unsafeGet(x).toInt() != nn) {
-              pc = pc + 2
+            if (v.get.unsafeGet(x).toInt() != nn) {
+              pc.set(pc.get + 2)
             }
-            pc = pc + 2
+            pc.set(pc.get + 2)
           }
           // Skip next instruction if VX == VY
           case 5 => {
-            if (v.unsafeGet(x).toInt() == v.unsafeGet(y).toInt()) {
-              pc = pc + 2
+            if (v.get.unsafeGet(x).toInt() == v.get.unsafeGet(y).toInt()) {
+              pc.set(pc.get + 2)
             }
-            pc = pc + 2
+            pc.set(pc.get + 2)
           }
           // Set VX = NN
           case 6 => {
-            v.unsafeSet(x, nn.toByte())
-            pc = pc + 2
+            v.get.unsafeSet(x, nn.toByte())
+            pc.set(pc.get + 2)
           }
           // Set VX = VX + NN
           case 7 => {
-            v.unsafeSet(x, (v.unsafeGet(x).toInt() + nn).toByte())
-            pc = pc + 2
+            v.get.unsafeSet(x, (v.get.unsafeGet(x).toInt() + nn).toByte())
+            pc.set(pc.get + 2)
           }
           case 8 => {
             n match {
               // Set VX = VY
               case 0 => {
-                v.unsafeSet(x, v.unsafeGet(y))
+                v.get.unsafeSet(x, v.get.unsafeGet(y))
               }
               // Set VX = VX OR VY
               case 1 => {
-                v.unsafeSet(x, bitwiseOr(v.unsafeGet(x).toInt(), v.unsafeGet(y).toInt()).toByte())
+                v.get.unsafeSet(x, bitwiseOr(v.get.unsafeGet(x).toInt(), v.get.unsafeGet(y).toInt()).toByte())
               }
               // Set VX = VX AND VY
               case 2 => {
-                v.unsafeSet(x, bitwiseAnd(v.unsafeGet(x).toInt(), v.unsafeGet(y).toInt()).toByte())
+                v.get.unsafeSet(x, bitwiseAnd(v.get.unsafeGet(x).toInt(), v.get.unsafeGet(y).toInt()).toByte())
               }
               // Set VX = VX XOR VY
               case 3 => {
-                v.unsafeSet(x, bitwiseXor(v.unsafeGet(x).toInt(), v.unsafeGet(y).toInt()).toByte())
+                v.get.unsafeSet(x, bitwiseXor(v.get.unsafeGet(x).toInt(), v.get.unsafeGet(y).toInt()).toByte())
               }
               // Set VX = VX + VY, set VF = carry
               case 4 => {
-                val sum = v.unsafeGet(x).toInt() + v.unsafeGet(y).toInt()
-                v.unsafeSet(x, sum.toByte())
-                v.unsafeSet(15, (if (sum > 255) 1 else 0).toByte())
+                val sum = v.get.unsafeGet(x).toInt() + v.get.unsafeGet(y).toInt()
+                v.get.unsafeSet(x, sum.toByte())
+                v.get.unsafeSet(15, (if (sum > 255) 1 else 0).toByte())
                 
               }
               // Set VX = VX - VY, set VF = NOT borrow
               case 5 => {
-                val vx = v.unsafeGet(x).toInt()
-                val vy = v.unsafeGet(y).toInt()
+                val vx = v.get.unsafeGet(x).toInt()
+                val vy = v.get.unsafeGet(y).toInt()
                 val sub = vx - vy
 
-                v.unsafeSet(x, sub.toByte())
-                v.unsafeSet(15, (if (vx > vy) 1 else 0).toByte())
+                v.get.unsafeSet(x, sub.toByte())
+                v.get.unsafeSet(15, (if (vx > vy) 1 else 0).toByte())
               }
               // Set VX = VX SHR 1 and VF = LSB of VX
               case 6 => {
-                val vx = v.unsafeGet(x).toInt()
+                val vx = v.get.unsafeGet(x).toInt()
                 val lsb = bitwiseAnd(vx, 1)
                 val vx_ = bitwiseShr(vx, 1)
-                v.unsafeSet(x, vx_.toByte())
-                v.unsafeSet(15, lsb.toByte())
+                v.get.unsafeSet(x, vx_.toByte())
+                v.get.unsafeSet(15, lsb.toByte())
               }
               // Set VX = VY - VX, set VF = NOT borrow
               case 7 => {
-                val vx = v.unsafeGet(x).toInt()
-                val vy = v.unsafeGet(y).toInt()
+                val vx = v.get.unsafeGet(x).toInt()
+                val vy = v.get.unsafeGet(y).toInt()
                 val sub = vy - vx
                 
-                v.unsafeSet(x, sub.toByte())
-                v.unsafeSet(15, (if (vy > vx) 1 else 0).toByte())
+                v.get.unsafeSet(x, sub.toByte())
+                v.get.unsafeSet(15, (if (vy > vx) 1 else 0).toByte())
               }
               // Set VX = VX SHL 1 and VF = MSB of VX
               case 14 => {
-                val vx = v.unsafeGet(x).toInt()
+                val vx = v.get.unsafeGet(x).toInt()
                 val msb = bitwiseAnd(vx, 128)
                 val vx_ = vx * 2
                 val vf = bitwiseShr(msb, 7)
-                v.unsafeSet(x, vx_.toByte())
-                v.unsafeSet(15, vf.toByte())
+                v.get.unsafeSet(x, vx_.toByte())
+                v.get.unsafeSet(15, vf.toByte())
               }
             } else {
               r.log("Unknown Instruction: " ++ show(inst))
             }
-            pc = pc + 2
+            pc.set(pc.get + 2)
           }
           // Skip next instruction if VX != VY
           case 9 => {
-            if (v.unsafeGet(x).toInt() != v.unsafeGet(y).toInt()) {
-              pc = pc + 2
+            if (v.get.unsafeGet(x).toInt() != v.get.unsafeGet(y).toInt()) {
+              pc.set(pc.get + 2)
             }
-            pc = pc + 2
+            pc.set(pc.get + 2)
           }
           // Set I = NNN
           case 10 => {
-            i = nnn
-            pc = pc + 2
+            i.set(nnn)
+            pc.set(pc.get + 2)
           }
           // Jump to location NNN + V0
           case 11 => {
-            pc = nnn + v.unsafeGet(0).toInt()
+            pc.set(nnn + v.get.unsafeGet(0).toInt())
           }
 
           // Set VX = random byte AND NN
           case 12 => {
             val randInt: Int = floor(random() * 255.0)
-            v.unsafeSet(x, bitwiseAnd(randInt, nn).toByte())
-            pc = pc + 2
+            v.get.unsafeSet(x, bitwiseAnd(randInt, nn).toByte())
+            pc.set(pc.get + 2)
           }
           // Display n-byte sprite starting at memory location I at (VX, VY), set VF = collision
           case 13 => {
-            val vx = v.unsafeGet(x).toInt()
-            val vy = v.unsafeGet(y).toInt()
+            val vx = v.get.unsafeGet(x).toInt()
+            val vy = v.get.unsafeGet(y).toInt()
             var collision = false
             var yline = 0
             
             while (yline < n) {
-              val pixel = ram.getAddr(i + yline)
+              val pixel = ram.getAddr(i.get + yline)
               var xline = 0
               
               while (xline < 8) {
@@ -285,27 +285,27 @@ def makeCPU() {r: Renderer} = {
               yline = yline + 1
             }
             
-            v.unsafeSet(15, (if (collision) 1 else 0).toByte())
-            pc = pc + 2
+            v.get.unsafeSet(15, (if (collision) 1 else 0).toByte())
+            pc.set(pc.get + 2)
           }
           case 14 => {
             nn match {
               // Skip next instruction if key with the value of VX is not pressed
               case 161 => {
-                val vx = v.unsafeGet(x).toInt()
-                if (key != v.unsafeGet(x).toInt()) {
-                  pc = pc + 4
+                val vx = v.get.unsafeGet(x).toInt()
+                if (key != v.get.unsafeGet(x).toInt()) {
+                  pc.set(pc.get + 4)
                 } else {
-                  pc = pc + 2
+                  pc.set(pc.get + 2)
                 }
               }
               // Skip next instruction if key with the value of VX is pressed
               case 158 => {
-                val vx = v.unsafeGet(x).toInt()
-                if (key != -1 && key == v.unsafeGet(x).toInt()) {
-                  pc = pc + 4
+                val vx = v.get.unsafeGet(x).toInt()
+                if (key != -1 && key == v.get.unsafeGet(x).toInt()) {
+                  pc.set(pc.get + 4)
                 } else {
-                  pc = pc + 2
+                  pc.set(pc.get + 2)
                 }
               }
             } else {
@@ -316,63 +316,63 @@ def makeCPU() {r: Renderer} = {
             nn match {
               // Set VX = delay timer value
               case 7 => {
-                v.unsafeSet(x, delay)
-                pc = pc + 2
+                v.get.unsafeSet(x, delay.get)
+                pc.set(pc.get + 2)
               }
               // Wait for a key press, store the value of the key in VX
               case 10 => {
                 if (key >= 0) {
-                  v.unsafeSet(x, key.toByte())
-                  pc = pc + 2
+                  v.get.unsafeSet(x, key.toByte())
+                  pc.set(pc.get + 2)
                 }
               }
               // SET delay timer = VX
               case 21 => {
-                delay = v.unsafeGet(x)
-                pc = pc + 2
+                delay.set(v.get.unsafeGet(x))
+                pc.set(pc.get + 2)
               }
               // Set sound timer = VX
               case 24 => {
-                sound = v.unsafeGet(x)
-                pc = pc + 2
+                sound.set(v.get.unsafeGet(x))
+                pc.set(pc.get + 2)
               }
               // SET I = I + VX
               case 30 => {
-                i = i + v.unsafeGet(x).toInt()
-                pc = pc + 2
+                i.set(i.get + v.get.unsafeGet(x).toInt())
+                pc.set(pc.get + 2)
               }
               // Set I = location of sprite for digit VX
               case 41 => {
-                i = v.unsafeGet(x).toInt() * 5
-                pc = pc + 2
+                i.set(v.get.unsafeGet(x).toInt() * 5)
+                pc.set(pc.get + 2)
               }
               // Store BCD representation of VX in memory locations I, I+1, and I+2
               case 51 => {
-                val vx = v.unsafeGet(x).toInt()
-                ram.setAddr(i, (vx / 100).toByte())
-                ram.setAddr(i + 1, mod((vx / 10), 10).toByte())
-                ram.setAddr(i + 2, mod(vx, 10).toByte())
-                pc = pc + 2
+                val vx = v.get.unsafeGet(x).toInt()
+                ram.setAddr(i.get, (vx / 100).toByte())
+                ram.setAddr(i.get + 1, mod((vx / 10), 10).toByte())
+                ram.setAddr(i.get + 2, mod(vx, 10).toByte())
+                pc.set(pc.get + 2)
               }
               // Store registers V0 through VX in memory starting at location I
               case 85 => {
                 var index = 0
                 while (index <= x) {
-                  ram.setAddr(i + index, v.unsafeGet(index))
+                  ram.setAddr(i.get + index, v.get.unsafeGet(index))
                   index = index + 1
                 }
                 // i = i + x + 1
-                pc = pc + 2
+                pc.set(pc.get + 2)
               }
               // Read registers V0 through VX from memory starting at location I
               case 101 => {
                 var index = 0
                 while (index <= x) {
-                  v.unsafeSet(index, ram.getAddr(i + index))
+                  v.get.unsafeSet(index, ram.getAddr(i.get + index))
                   index = index + 1
                 }
                 // i = i + x + 1
-                pc = pc + 2
+                pc.set(pc.get + 2)
               }
             } else {
               r.log("Unknown Instruction: " ++ show(inst))
@@ -381,22 +381,22 @@ def makeCPU() {r: Renderer} = {
         } else {
           r.log("Unknown Instruction: " ++ show(inst))
         }
-        last_instruction_run_time = getNow()
+        last_instruction_run_time.set(getNow())
 
         // Update timers if needed
-        if (currentTime - last_timer_update >= 16) { // 60Hz timer updates
+        if (currentTime - last_timer_update.get >= 16) { // 60Hz timer updates
           // Update timers
-          if (delay.toInt() > 0) {
-            delay = (delay.toInt() - 1).toByte()
+          if (delay.get.toInt() > 0) {
+            delay.set((delay.get.toInt() - 1).toByte())
           }
-          if (sound.toInt() > 0) {
-            sound = (sound.toInt() - 1).toByte()
+          if (sound.get.toInt() > 0) {
+            sound.set((sound.get.toInt() - 1).toByte())
             r.beep()
           } else {
             r.stopBeep()
           }
           
-          last_timer_update = currentTime
+          last_timer_update.set(currentTime)
         }
       }
     }

--- a/src/ram.effekt
+++ b/src/ram.effekt
@@ -8,12 +8,12 @@ interface Ram {
   def init(rom: ByteArray): Unit  
 }
 
-def get(ram: ByteArray, address: Int): Byte = ram.unsafeGet(address)
-def set(ram: ByteArray, address: Int, byte: Byte): Unit = ram.unsafeSet(address, byte)
-def set(ram: ByteArray, address: Int, value: Int): Unit = ram.unsafeSet(address, value.toByte)
+def get(ram: Ref[ByteArray], address: Int): Byte = ram.get.unsafeGet(address)
+def set(ram: Ref[ByteArray], address: Int, byte: Byte): Unit = ram.get.unsafeSet(address, byte)
+def set(ram: Ref[ByteArray], address: Int, value: Int): Unit = ram.get.unsafeSet(address, value.toByte)
 
 // Load the predefined fontset. There is no better way to do this, since they are hardcoded values.
-def loadFont(ram: ByteArray): Unit = {
+def loadFont(ram: Ref[ByteArray]): Unit = {
   // Since there is no way to represent hex literals in Effekt, we have to use decimal literals and convert them to bytes.
   val fontSet: List[Byte] = [
     240.toByte, 144.toByte, 144.toByte, 144.toByte, 240.toByte, // 0
@@ -39,12 +39,12 @@ def loadFont(ram: ByteArray): Unit = {
 }
 
 // Load the ROM into memory starting at 0x200 (512)
-def loadRom(ram: ByteArray, rom: ByteArray): Unit = rom.foreachIndex { (i, byte) =>
+def loadRom(ram: Ref[ByteArray], rom: ByteArray): Unit = rom.foreachIndex { (i, byte) =>
   set(ram, 512 + i, byte)
 }
 
 def makeRam() = {
-  var ram: ByteArray in global = allocate(4096) // 4KB of memory
+  val ram: Ref[ByteArray] = ref(allocate(4096)) // 4KB of memory
   new Ram {
     def getAddr(address: Int) = get(ram, address)
     def setAddr(address: Int, byte: Byte) = set(ram, address, byte)


### PR DESCRIPTION
The `in global` syntax is now unsupported, see https://github.com/effekt-lang/effekt/pull/909

Not sure about performance or whether all these mutable references are actually needed, but this fixes the compilation at least.

Slightly off-topic but I think a `ref.update` would be a great addition to `ref.effekt`

```
def update[T](ref: Ref[T]) { f: T => T }: Unit =
  ref.set(f(ref.get))
```